### PR TITLE
Use tox and pytest to run tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+build/
+.cache
+.coverage
+*.egg-info
 __pycache__
 *.pyc
 *.pyo
+.pytest_cache
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ python:
   - "2.7"
   - "3.6"
 # command to install dependencies
-install: "python setup.py install"
+install: "pip install tox tox-travis"
 # command to run tests
-script: python -m unittest discover 
+script: tox
 notifications:
   email:
     recipients:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+-e .
+pytest
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 -e .
+pycrypto
 pytest
 pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[coverage:run]
+omit =
+    *test*
+
+[tox]
+envlist = py27, py36
+
+[testenv]
+passenv = TRAVIS TRAVIS_*
+deps = -r{toxinidir}/requirements.txt
+commands =
+    py.test --cov=KalturaClient --verbose


### PR DESCRIPTION
Use pytest as the test discoverer, which is much more sophisticated
than the basic unittest runner, and has a lot more features, like
coverage reporting (now enabled).

Use tox to take care of running pytest with the correct parameters
and trigger that from Travis instead of running the test runner
directly (the tox-travis plugin ensures tox does not complain about
missing Python versions when run in an environment with only one
version).